### PR TITLE
Upgrade Puma from version 6 to version 7 for Heroku

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem "sprockets-rails"
 gem "pg", "~> 1.1"
 
 # Use the Puma web server [https://github.com/puma/puma]
-gem "puma", "~> 6.0"
+gem "puma", "~> 7.1.x"
 
 # Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]
 gem "importmap-rails"
@@ -31,7 +31,7 @@ gem "redis"
 # gem "kredis"
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
-gem "bcrypt", "~> 3.1.7"
+gem "bcrypt", "~> 3.1.x"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[windows jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -366,7 +366,7 @@ GEM
       date
       stringio
     public_suffix (6.0.2)
-    puma (6.6.1)
+    puma (7.1.0)
       nio4r (~> 2.0)
     pundit (2.5.2)
       activesupport (>= 3.0.0)
@@ -697,7 +697,7 @@ DEPENDENCIES
   audited
   aws-sdk-s3
   barnes
-  bcrypt (~> 3.1.7)
+  bcrypt (~> 3.1.x)
   bootsnap
   capybara
   cuprite
@@ -721,7 +721,7 @@ DEPENDENCIES
   positioning
   prosopite
   pry (~> 0.14.2)
-  puma (~> 6.0)
+  puma (~> 7.1.x)
   pundit
   pundit-matchers (~> 4.0)
   rack-timeout

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,11 +1,3 @@
-# Use Barnes for Ruby runtime metrics
-# https://devcenter.heroku.com/articles/language-runtime-metrics-ruby#add-the-barnes-gem-to-your-application
-require "barnes"
-
-before_fork do
-  Barnes.start
-end
-
 # Puma can serve each request in a thread from an internal thread pool.
 # The `threads` method setting takes two numbers: a minimum and maximum.
 # Any libraries that use thread pools should be configured to match
@@ -59,3 +51,7 @@ preload_app!
 
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart
+
+# Router keepalive idle timeout + 5 seconds
+# https://devcenter.heroku.com/articles/http-routing#keepalives
+persistent_timeout 95


### PR DESCRIPTION
Remove Barnes integration and enable worker mode with preload_app. Add persistent timeout of 95 seconds for Heroku router compatibility.