### PR TITLE
Reduce loading time on edit purchase item page

### DIFF
--- a/app/javascript/controllers/slim_select_controller.js
+++ b/app/javascript/controllers/slim_select_controller.js
@@ -34,6 +34,6 @@ export default class extends Controller {
   }
 
   hasSlimSelectUi() {
-    return Boolean(this.element.parentElement?.querySelector(".ss-main"));
+    return Boolean(this.element.nextElementSibling?.classList.contains("ss-main"));
   }
 }

--- a/app/models/sale_item/listing.rb
+++ b/app/models/sale_item/listing.rb
@@ -9,6 +9,8 @@ module SaleItem::Listing
     scope :for_linking, -> {
       includes(
         :product,
+        :shopify_info,
+        :woo_info,
         sale: [:customer],
         variant: [:color, :size, :version]
       )

--- a/app/models/sale_item/titling.rb
+++ b/app/models/sale_item/titling.rb
@@ -14,8 +14,9 @@ module SaleItem::Titling
     status = sale.status&.titleize
     email = sale.customer.email
     pretty_sale_id = "Sale ID: #{sale_id}"
-    pretty_woo_id = woo_store_id && "Woo ID: #{woo_store_id}"
+    pretty_woo_id = woo_store_id && "Woo: #{woo_store_id}"
+    pretty_shopify_id = shopify_store_id && "Shopify: #{shopify_info.id_short}"
 
-    [id, status, title, email, pretty_sale_id, pretty_woo_id].compact.join(" | ")
+    [id, status, title, email, pretty_sale_id, pretty_woo_id, pretty_shopify_id].compact.join(" | ")
   end
 end

--- a/app/models/store_info/references.rb
+++ b/app/models/store_info/references.rb
@@ -29,6 +29,8 @@ module StoreInfo::References
     case our_name
     when "Sale"
       "Order"
+    when "SaleItem"
+      "LineItem"
     when "Variant"
       "ProductVariant"
     else

--- a/app/views/purchase_items/form/_form.html.slim
+++ b/app/views/purchase_items/form/_form.html.slim
@@ -1,11 +1,11 @@
 = form_with(model: purchase_item, url: local_assigns[:form_url], html: {multipart: true}) do |form|
-  = form.label :warehouse
+  = form.label :warehouse_id
   = form.collection_select :warehouse_id, @warehouse_options || [], :id, :name, {include_blank: true}, slim_select_html_options
 
-  = form.label :purchase
+  = form.label :purchase_id
   = form.collection_select :purchase_id, @purchases || [], :id, :full_title, {include_blank: true}, slim_select_html_options
 
-  = form.label :sale_item
+  = form.label :sale_item_id
   = form.collection_select :sale_item_id, @sale_items || [], :id, :build_title_for_select, {include_blank: true}, slim_select_html_options
 
   fieldset.flex.justify-between.gap-4.flex-col.lg:flex-row
@@ -33,7 +33,7 @@
       = form.label :tracking_number
       = form.text_field :tracking_number
     .block.w-full
-      = form.label :shipping_company
+      = form.label :shipping_company_id
       = form.collection_select :shipping_company_id, @shipping_companies || [], :id, :name, {include_blank: true}, slim_select_html_options
 
   = render "_shared/media_form", form: form, resource_name: "purchase item"


### PR DESCRIPTION
- Use _id suffix on form labels for warehouse, purchase, sale_item, shipping_company
- Fix hasSlimSelectUi to check nextElementSibling instead of parentElement query
- Include shopify_info and woo_info in for_linking scope to avoid N+1
- Add Shopify ID to sale item select title; shorten Woo label prefix
- Map SaleItem to LineItem in StoreInfo::References

this pr resolves #189