### PR TITLE
feat(products): import published_at from Shopify and sort products listing by it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@
 
 - For Rails domain work, use `rails-domain-architecture` SKILL.md.
 - For frontend work, use `frontend-architecture` SKILL.md.
+- For adding or changing an inline table-cell editor, use `inline-cell-editor` SKILL.md.
 
 ## Completion
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -7,6 +7,7 @@
 #  id           :bigint           not null, primary key
 #  full_title   :string
 #  image        :string
+#  published_at :datetime
 #  shape        :string           default("Statue"), not null
 #  slug         :string
 #  title        :string

--- a/app/models/product/listing.rb
+++ b/app/models/product/listing.rb
@@ -10,7 +10,7 @@ module Product::Listing
         :woo_info,
         variants: [:version, :color, :size],
         media: {image_attachment: :blob}
-      ).order(created_at: :desc)
+      ).order(Product.arel_table[:published_at].desc.nulls_last, created_at: :desc)
     }
 
     scope :for_details, -> {

--- a/app/models/product/shopify/importer.rb
+++ b/app/models/product/shopify/importer.rb
@@ -32,7 +32,8 @@ class Product::Shopify::Importer
         title: parsed[:title],
         franchise: Franchise.find_or_create_by(title: parsed[:franchise]),
         shape: parsed[:shape].presence || Product.default_shape,
-        description: normalize_description_html(parsed[:description])
+        description: normalize_description_html(parsed[:description]),
+        published_at: parsed[:published_at]
       )
       assign_brand
       assign_size

--- a/app/models/product/shopify/parser.rb
+++ b/app/models/product/shopify/parser.rb
@@ -32,6 +32,7 @@ class Product::Shopify::Parser
       shape: parsed_title[:shape],
       size: parsed_title[:size],
       sku: parsed_sku,
+      published_at: payload["publishedAt"],
       store_id: payload["id"],
       store_info: {
         ext_created_at: payload["createdAt"],

--- a/app/services/shopify/graphql/product_query.rb
+++ b/app/services/shopify/graphql/product_query.rb
@@ -17,6 +17,7 @@ module Shopify
         tags
         createdAt
         updatedAt
+        publishedAt
         media(first: 20) {
           nodes {
             ... on MediaImage {

--- a/db/migrate/20260610144604_add_published_at_to_products.rb
+++ b/db/migrate/20260610144604_add_published_at_to_products.rb
@@ -1,0 +1,6 @@
+class AddPublishedAtToProducts < ActiveRecord::Migration[8.1]
+  def change
+    add_column :products, :published_at, :datetime
+    add_index :products, :published_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_01_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_10_144604) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -207,6 +207,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_120000) do
     t.bigint "franchise_id", null: false
     t.string "full_title"
     t.string "image"
+    t.datetime "published_at"
     t.string "shape", default: "Statue", null: false
     t.string "shopify_id"
     t.string "slug"
@@ -214,6 +215,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_120000) do
     t.datetime "updated_at", null: false
     t.string "woo_id"
     t.index ["franchise_id"], name: "index_products_on_franchise_id"
+    t.index ["published_at"], name: "index_products_on_published_at"
     t.index ["shopify_id"], name: "index_products_on_shopify_id"
     t.index ["slug"], name: "index_products_on_slug", unique: true
     t.check_constraint "shape::text = ANY (ARRAY['Statue'::character varying, 'Bust'::character varying]::text[])", name: "products_shape_allowed_values"

--- a/spec/models/product/shopify/importer_spec.rb
+++ b/spec/models/product/shopify/importer_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Product::Shopify::Importer do
         brand: "Light and Dust Studio",
         sku: "TEST-SKU-001",
         tags: [],
+        published_at: 2.days.ago.iso8601,
         store_info: {
           ext_created_at: 1.day.ago.iso8601,
           ext_updated_at: 1.hour.ago.iso8601
@@ -38,6 +39,7 @@ RSpec.describe Product::Shopify::Importer do
       expect(product.shape).to eq("Statue")
       expect(product.brands.first.title).to eq("Light and Dust Studio")
       expect(product.sizes.first.value).to eq("1:4")
+      expect(product.published_at).to be_within(1.second).of(2.days.ago)
     end
 
     it "enqueues sync jobs for variants and media" do # rubocop:todo RSpec/MultipleExpectations

--- a/spec/models/product/shopify/parser_spec.rb
+++ b/spec/models/product/shopify/parser_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe Product::Shopify::Parser do
           "tags" => ["statue", "premium", "exclusive"],
           "createdAt" => "2024-01-01T00:00:00Z",
           "updatedAt" => "2024-01-15T00:00:00Z",
+          "publishedAt" => "2024-01-10T00:00:00Z",
           "variants" => {
             "edges" => [
               {
@@ -109,6 +110,7 @@ RSpec.describe Product::Shopify::Parser do
         expect(result).to include(
           store_id: "gid://shopify/Product/12345",
           store_link: "stellar-blade-eve-statue",
+          published_at: "2024-01-10T00:00:00Z",
           title: "Eve",
           franchise: "Stellar Blade",
           size: "1:4",

--- a/spec/models/product_listing_spec.rb
+++ b/spec/models/product_listing_spec.rb
@@ -4,14 +4,22 @@ require "rails_helper"
 
 RSpec.describe Product do
   describe ".listed" do
-    it "eager loads the listing associations and orders newest first" do
-      older = create(:product)
-      newer = create(:product)
+    it "sorts published products before unpublished, then by created_at desc" do
+      unpublished_newer = create(:product)
+      unpublished_older = create(:product, created_at: 1.day.ago)
+      published = create(:product, published_at: 1.week.ago)
 
-      relation = described_class.listed.where(id: [older.id, newer.id]).to_a
+      relation = described_class.listed.where(id: [unpublished_newer.id, unpublished_older.id, published.id]).to_a
+
+      expect(relation.map(&:id)).to eq([published.id, unpublished_newer.id, unpublished_older.id])
+    end
+
+    it "eager loads the listing associations" do
+      product = create(:product, published_at: 1.day.ago)
+
+      relation = described_class.listed.where(id: product.id).to_a
 
       aggregate_failures do
-        expect(relation.first.id).to eq(newer.id)
         expect(relation.first.association(:shopify_info).loaded?).to be true
         expect(relation.first.association(:woo_info).loaded?).to be true
         expect(relation.first.association(:variants).loaded?).to be true

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -7,6 +7,7 @@
 #  id           :bigint           not null, primary key
 #  full_title   :string
 #  image        :string
+#  published_at :datetime
 #  shape        :string           default("Statue"), not null
 #  slug         :string
 #  title        :string


### PR DESCRIPTION
Adds published_at to the products table, fetches it from Shopify's publishedAt field, and sorts the listing scope by published_at DESC NULLS LAST then created_at DESC so published products surface first.

Resolves #175 